### PR TITLE
Add Dockerfile and docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM elixir:latest
+
+RUN mix local.hex --force
+RUN mix local.rebar --force
+
+RUN mix escript.install --force github marcelotto/skout
+
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/root/.mix/escripts

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Skout is written in Elixir. This means you'll have to have [Elixir installed](ht
 
 ```sh
 $ mix escript.install github marcelotto/skout
-``` 
+```
 
 After installation, the escript can be invoked as
 
@@ -336,7 +336,7 @@ concept_scheme:
 ---
 Foo:
 - Bar baz
-``` 
+```
 
 This will be translated now to these RDF statements:
 
@@ -377,7 +377,24 @@ $ skout input.nt output.yml
 
 Run `skout --help` to see all available options.
 
+### Docker
 
+Assuming Docker and docker-compose are installed, you can avoid installing Elixir building a Docker image to run Skout in a Docker container. 
+
+You can build the image using one of the following commands. It is possible customize the image tag in the command or in the docker-compose.
+```sh
+$ docker build -t myrepository/skout .
+```
+or
+```
+$ docker-compose build
+```
+The repository also contains a docker-compose configured to run the example in the _examples_ folder. In the provided docker-compose, the _examples_ folder is mounted as a volume, so the output file can be found there. It is possible to customize the docker-compose modifying the mounted folder and the commands executed.
+
+To run the example you can simply use the command:
+```sh
+$ docker-compose up
+```
 
 ## Contributing
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  skout: 
+    image: myrepository/skout:latest
+    build:
+      context: ./
+    working_dir: /usr/src/myapp
+    volumes:
+      - ./examples:/usr/src/myapp
+    entrypoint: ["skout", "vehicle_types.yml", "output.ttl"]


### PR DESCRIPTION
Hi,
thank you for sharing this useful project! I created a Dockerfile and an example docker-compose to run *skout* in Docker without requiring to install Elixir locally.  I tested it with the file in the *examples* folder and it seems to work properly.

Commands:
- Build the image: `docker build -t myrepository/skout .`  or  `docker-compose build`
- Run the example: `docker-compose up`

*examples* folder is mounted as a volume, the output file can be found there.

The user can customize directly in the docker-compose the image tag, the mounted folder and the command executed.